### PR TITLE
Rework commands and add queue for !say command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ $RECYCLE.BIN/
 
 twitchPermissionsTokens.json
 config.json
+config.yaml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Node Inspector",
+			"type": "node",
+			"request": "launch",
+			"args": ["${workspaceRoot}/src/index.ts"],
+			"runtimeArgs": ["-r", "ts-node/register"],
+			"cwd": "${workspaceRoot}",
+			"protocol": "inspector",
+			"internalConsoleOptions": "openOnSessionStart",
+			"env": {
+				"TS_NODE_IGNORE": "false"
+			}
+		}
+	]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,6 +123,12 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
+    "@types/js-yaml": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.4.tgz",
+      "integrity": "sha512-fYMgzN+9e28R81weVN49inn/u798ruU91En1ZnGvSZzCRc5jXx9B2EDhlRaWmcO1RIxFHL8AajRXzxDuJu93+A==",
+      "dev": true
+    },
     "@types/lodash": {
       "version": "4.14.150",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",
@@ -222,6 +228,14 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -1630,6 +1644,15 @@
         "meow": "~3.7.0"
       }
     },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -2907,6 +2930,11 @@
           }
         }
       }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "ssf": {
       "version": "0.10.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "chokidar": "^3.2.3",
+    "js-yaml": "^3.13.1",
     "node-nlp": "^3.5.2",
     "obs-websocket-js": "^3.1.0",
     "say": "^0.16.0",
@@ -22,6 +23,7 @@
     "yargs": "^15.3.1"
   },
   "devDependencies": {
+    "@types/js-yaml": "^3.12.4",
     "@types/lodash": "^4.14.150",
     "@types/node": "^13.13.2",
     "@types/tmi.js": "^1.4.0",

--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -1,36 +1,12 @@
-import {Userstate} from 'tmi.js';
+import {ChatUserstate} from 'tmi.js';
 
-export type CommandBody = (...args:any) => void;
+export default abstract class Command {
+    public command: string;
 
-export default class Command {
-    isSubOnly: boolean;
-    command: string;
-    closure: () => void;
-    userPermissionsList: string[];
-
-    constructor(command: string, closure: CommandBody, userPermissionsList=[], isSubOnly=false) {
-        this.isSubOnly = isSubOnly;
+    public constructor(command: string) {
         this.command = command;
-        this.closure = closure;
-        this.userPermissionsList = userPermissionsList;
     }
 
-    isAllowedFor(userstate: Userstate): boolean {
-        const username = userstate.username;
-        if (this.isSubOnly && !userstate.subscriber) {
-            return false;
-        }
-        if (!this.userPermissionsList.length) {
-            return true;
-        }
-        return this.userPermissionsList.includes(username);
-    }
+    public abstract async execute(userstate: ChatUserstate, message: string): Promise<void>
 
-    execute(userstate: Userstate, message: string): void {
-        const username = userstate.username;
-        if (!this.isAllowedFor(username)) {
-            return;
-        }
-        this.closure();
-    }
 }

--- a/src/commands/SayCommand.ts
+++ b/src/commands/SayCommand.ts
@@ -1,72 +1,83 @@
-import Command from './Command';
 import say from 'say';
-import { Userstate } from 'tmi.js';
-import { SayInChatFunc } from '../utils';
+import { ChatUserstate } from 'tmi.js';
+import { promisify } from 'util';
+
+import Command from './Command';
+import { sayInChat } from '../utils';
 
 import config from '../config';
 
-const channel = config.channel;
 
-interface SayTimeouts {
-    [username: string]: number
-}
+const speak = promisify(say.speak.bind(say));
 
 interface SayLengthPermissions {
     [username: string]: number
 }
 
-const sayTimeout = 60000;
-const sayTimeoutRecord: SayTimeouts = {};
-const sayLengthPermissions: SayLengthPermissions = {
-    channel: 0,
-}
+type SpeechAssist = [string, string];
+
+const speechAssistReplacements:SpeechAssist[] = [
+    ['decebot', 'dece bot'],
+    ['dece', 'deese'],
+    ['nani', 'naw knee']
+]
 
 export default class SayCommand extends Command {
-    sayInChat: SayInChatFunc;
-
-    constructor(command: string, sayInChat: SayInChatFunc, userPermissionsList = []) {
-        super(command, sayInChat, userPermissionsList);
-
-        this.sayInChat = sayInChat;
+    // This is a theoretical memory leak since we are never removing records from here.
+    // It's probably fine
+    private readonly sayLengthPermissions: SayLengthPermissions = {
+        [config.channel]: 0,
     }
 
-    execute(userstate: Userstate, message: string) {
-        const username = userstate.username;
-        const sayInChat = this.sayInChat;
-        const say_text = message.toLowerCase().replace("!say", "").replace("decebot", "dece bot").replace("dece", "deese");
-        if (!say_text.length || username == config.botName) {
+    constructor(command: string) {
+        super(command);
+    }
+
+    public execute = async (user: ChatUserstate, message: string) => {
+        const sayText = this.parseCommand(message);
+        if (!sayText.length) {
             return;
         }
-        if (sayTimeoutRecord[username]) {
-            const lastTime = sayTimeoutRecord[username];
-            const elapsedTime = Date.now() - lastTime;
-            if (elapsedTime < sayTimeout && !userstate.mod) {
-                sayInChat(`Yo ${username}, chill out with the !say command for at least another ${Math.ceil((sayTimeout - elapsedTime) / 1000)} seconds`);
-                return;
-            } else {
 
-            }
-        }
-        sayTimeoutRecord[username] = Date.now();
-        say.speak(say_text, config.sayVoice, 1.0, function (err) { // "Microsoft Zira Desktop"
-            if (err) {
-                console.log(`FAILED attempt to speak: ${say_text}`)
-            } else {
-                console.log(`SUCCESS text to speech: ${say_text}`)
-            }
-            delete sayTimeoutRecord[username];
-        });
+        const username = user.username as string;
 
-        const timeout = sayLengthPermissions.hasOwnProperty(username) ? sayLengthPermissions[username] : 10000;
+        const maxSayDuration = this.sayLengthPermissions.hasOwnProperty(username) ? this.sayLengthPermissions[username] : config.sayTimeout;
+        // const maxSayDuration = config.sayTimeout;
 
-        if (timeout > 0) {
-            setTimeout(() => {
-                say.stop((err) => {
-                    if (!err) {
+        let cutoffMessage: NodeJS.Timeout|undefined = undefined;
+        let speaking = true;
+        if (maxSayDuration > 0) {
+            cutoffMessage = setTimeout(() => {
+                say.stop(err => {
+                    if (!err && speaking) {
                         sayInChat(`@${username} your message was too long so I had to cut off.`);
                     }
                 });
-            }, timeout)
+            }, maxSayDuration);
         }
+
+        try {
+            await speak(sayText, config.sayVoice, 1.0);
+        } catch (err) {
+            console.log(`FAILED text to speech: ${sayText}`)
+            if (config.debug) {
+                console.error(err);
+            }
+            return;
+        } finally {
+            speaking = false;
+            if(cutoffMessage) {
+                clearTimeout(cutoffMessage);
+            }
+        }
+
+        console.log(`SUCCESS text to speech: ${sayText}`)
+    }
+
+    private parseCommand = (rawText: string): string => {
+        return speechAssistReplacements.reduce(
+            (str, replacement) => str.replace(replacement[0], replacement[1]),
+                rawText.toLowerCase().slice('!say'.length).trim()
+        ).trim();
     }
 }

--- a/src/commands/SayCommand.ts
+++ b/src/commands/SayCommand.ts
@@ -3,7 +3,7 @@ import say from 'say';
 import { Userstate } from 'tmi.js';
 import { SayInChatFunc } from '../utils';
 
-import * as config from '../../config.json';
+import config from '../config';
 
 const channel = config.channel;
 

--- a/src/commands/SimpleCommand.ts
+++ b/src/commands/SimpleCommand.ts
@@ -1,0 +1,14 @@
+import { Command } from ".";
+import { ChatUserstate } from "tmi.js";
+
+export default class SimpleCommand extends Command {
+
+    constructor(command: string, private readonly closure: () => Promise<void> | void) {
+        super(command);
+    }
+
+    public execute = async (userstate: ChatUserstate, message: string) => {
+        await this.closure();
+    }
+
+}

--- a/src/commands/SoundCommand.ts
+++ b/src/commands/SoundCommand.ts
@@ -3,7 +3,7 @@ import { SayInChatFunc } from "../utils";
 
 import Command from './Command';
 import soundPlayer from 'sound-play';
-import * as config from '../../config.json';
+import config from '../config';
 
 export default class SoundCommand extends Command {
     sayInChat: SayInChatFunc

--- a/src/commands/SoundCommand.ts
+++ b/src/commands/SoundCommand.ts
@@ -1,31 +1,19 @@
-import { Userstate } from "tmi.js";
-import { SayInChatFunc } from "../utils";
+import { ChatUserstate } from "tmi.js";
 
 import Command from './Command';
 import soundPlayer from 'sound-play';
-import config from '../config';
 
 export default class SoundCommand extends Command {
-    sayInChat: SayInChatFunc
     filePath: string
 
-    constructor(command: string, filePath: string, sayInChat: SayInChatFunc, isSubOnly: boolean) {
-        super(command, sayInChat, [], isSubOnly);
+    constructor(command: string, filePath: string) {
+        super(command);
         this.filePath = filePath;
-        this.sayInChat = sayInChat;
     }
 
-    execute(userstate: Userstate, message: string) {
-        const username = userstate.username;
+    public execute = async (userstate: ChatUserstate, message: string) => {
         const filePath = this.filePath;
-        if (username == config.botName) {
-            return;
-        }
-        if (!this.isAllowedFor(userstate)) {
-            this.sayInChat(`Yo ${username}, you are not allowed to use this command: ${this.command}`);
-            return;
-        }
 
-        soundPlayer.play(filePath);
+        await soundPlayer.play(filePath);
     }
 }

--- a/src/commands/decorators.ts
+++ b/src/commands/decorators.ts
@@ -1,0 +1,167 @@
+import Command from './Command';
+import { ChatUserstate } from 'tmi.js';
+
+import { sayInChat, sleep } from '../utils';
+import { EventEmitter } from 'events';
+import config from '../config';
+
+interface SayTimeouts {
+    [username: string]: number
+}
+
+interface ThrottleOptions {
+    waitTime: number;
+    modsImmune?: boolean;
+    sharedTimeout?: SayTimeouts;
+}
+
+interface CommandInfo {
+    user: ChatUserstate;
+    message: string;
+}
+
+type CommandQueue = CommandInfo[];
+
+interface QueueOptions {
+    maxQueueSize?: number;
+    commandSpacing?: number;
+    sharedQueue?: CommandQueue
+}
+
+type AllowedUsers = string[] | ( (userstate:ChatUserstate) => boolean );
+
+export const allowedUsers = (inner: Command, allowedUsers: AllowedUsers) => {
+    return new class extends Command {
+
+        public execute = async (userstate: ChatUserstate, message: string) => {
+            let shouldExecute = false;
+            const username = userstate.username as string;
+
+            if (typeof(allowedUsers) === 'function') {
+                if (allowedUsers(userstate)) {
+                    shouldExecute = true;
+                }
+            } else if (Array.isArray(allowedUsers)) {
+                if (allowedUsers.includes(username)) {
+                    shouldExecute = true;
+                }
+            }
+
+            if (shouldExecute) {
+                await inner.execute(userstate, message);
+            } else {
+                sayInChat(`Yo ${username}, you are not allowed to use this command: ${this.command}`);
+            }
+        }
+
+    }(inner.command);
+};
+
+export const subOnly = (inner: Command, isSubOnly: boolean = true) => allowedUsers(inner, (user) => {
+    return !!(isSubOnly ? (user.subscriber || user.badges?.subscriber) : true);
+})
+
+export const throttle = (inner: Command, options: ThrottleOptions): Command => {
+    return new class extends Command {
+
+        private readonly sayTimeoutRecords: SayTimeouts = options.sharedTimeout || {};
+
+        public execute = async (userstate: ChatUserstate, message: string) => {
+            if (this.checkTimeout(userstate)) {
+                return;
+            }
+
+            await inner.execute(userstate, message);
+        }
+
+        private checkTimeout = (userstate: ChatUserstate) => {
+            const username = userstate.username as string;
+
+            if (userstate.badges?.broadcaster || (options.modsImmune && userstate.mod)) {
+                return false;
+            }
+
+            if (this.sayTimeoutRecords[username]) {
+                const lastTime = this.sayTimeoutRecords[username];
+                const elapsedTime = Date.now() - lastTime;
+                if (elapsedTime < options.waitTime) {
+                    sayInChat(`Yo ${username}, chill out with the ${inner.command} command for at least another ${Math.ceil((options.waitTime - elapsedTime) / 1000)} seconds`);
+                    return true;
+                } else {
+                    delete this.sayTimeoutRecords[username];
+                }
+            }
+
+            return false;
+        }
+
+    }(inner.command);
+}
+
+export const queued = (inner:Command, options:QueueOptions = {}) => {
+    return new class extends Command {
+
+        private readonly commandQueue: CommandQueue = options.sharedQueue || [];
+
+        private eventEmitter: EventEmitter = new EventEmitter();
+
+        constructor() {
+            super(inner.command);
+
+            config.debug && this.eventEmitter.on('commandQueued', (commandInfo: CommandInfo) => {
+                console.log(`Queuing command: '${commandInfo.message}'`);
+            })
+
+            this.runQueue();
+        }
+
+        public execute = async (user: ChatUserstate, message: string): Promise<void> => {
+            if (options.maxQueueSize !== undefined && this.commandQueue.length >= options.maxQueueSize) {
+                sayInChat(`@${user.username}, I cannot run ${inner.command} because the queue is full. Please wait and try again.`)
+                return;
+            }
+
+            this.enqueueCommand({user, message});
+        }
+
+        private enqueueCommand = (command: CommandInfo) => {
+            this.commandQueue.push(command);
+
+            this.eventEmitter.emit('commandQueued', command);
+        }
+
+        private runQueue = async () => {
+            while (await this.waitForCommand()) {
+                await this.tryDequeue();
+            }
+        }
+
+        private waitForCommand = (): Promise<boolean> => {
+            return new Promise(resolve => {
+                if (this.commandQueue.length) {
+                    resolve(true);
+                } else {
+                    this.eventEmitter.once('commandQueued', () => {
+                        resolve(true)
+                    });
+                }
+            })
+        }
+
+        private tryDequeue = async () => {
+            const nextItem = this.commandQueue.shift();
+
+            if (nextItem === undefined) {
+                return;
+            }
+
+            config.debug && console.log(`Running command: '${nextItem.message}'`)
+
+            await inner.execute(nextItem.user, nextItem.message);
+
+            if (options.commandSpacing !== undefined) {
+                await sleep(options.commandSpacing);
+            }
+        }
+    }();
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,7 +4,7 @@ import Command from './Command';
 import SayCommand from "./SayCommand";
 import SoundCommand from "./SoundCommand";
 import { sayInChat } from "../utils";
-import * as config from '../../config.json';
+import config from '../config';
 
 export { Command, SayCommand, SoundCommand };
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,30 +5,33 @@ import SayCommand from "./SayCommand";
 import SoundCommand from "./SoundCommand";
 import { sayInChat } from "../utils";
 import config from '../config';
+import SimpleCommand from "./SimpleCommand";
+import { subOnly, throttle, queued } from "./decorators";
 
 export { Command, SayCommand, SoundCommand };
 
-export const commands = [
+export const commands: Command[] = [
   // Text to speech command:
-  new SayCommand('!Say', (message) => {
-    sayInChat(message);
-  }),
+  throttle(
+    queued(new SayCommand('!Say')),
+    { waitTime: config.sayThrottleTime }
+  ),
 
   // DeceBot text commands:
-  new Command('!Discord', () => {
+  new SimpleCommand('!Discord', () => {
     sayInChat('Join the discord here: https://discord.gg/65jUQ8G');
   }),
-  new Command('!Github', () => {
+  new SimpleCommand('!Github', () => {
     sayInChat(
       'Wanna see what my insides look like? https://github.com/micantre/DeceBot'
     );
   }),
-  new Command('!CupheadWars', () => {
+  new SimpleCommand('!CupheadWars', () => {
     sayInChat(
       'The great Cuphead Wars of 2020 is a competition between me and a couple of my coworkers to see who can beat cuphead the fastest. Others in the competition are https://www.twitch.tv/kishkishftw and https://www.twitch.tv/faultymuse'
     );
   }),
-  new Command('!NewSoundboard', () => {
+  new SimpleCommand('!NewSoundboard', () => {
     sayInChat(
       'The subscriber sound effect commands are now shared in one collective subscriber soundboard.'
     );
@@ -44,6 +47,7 @@ export const commands = [
     path.join(soundBoardPath, 'General'),
     path.join(soundBoardPath, 'SubOnly'),
   ];
+
   try {
     const writePromises: Promise<void>[] = [];
     for (const folderPath of folderPaths) {
@@ -57,7 +61,7 @@ export const commands = [
         const fullPath = path.join(folderPath, file);
         const command = `!${file.split('.')[0]}`;
         commands.push(
-          new SoundCommand(command, fullPath, sayInChat, isSubOnly)
+          subOnly(new SoundCommand(command, fullPath), isSubOnly)
         );
         commandsInFolder.push(command);
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,93 @@
+import { safeLoad } from 'js-yaml';
+import { readFileSync } from 'fs';
+
+export interface Config {
+  /**
+   * Login name for the bot
+   */
+  botName: string;
+
+  /**
+   * Channel to speak in
+   */
+  channel: string;
+
+  /**
+   * Channels to connect to
+   */
+  channels: string[];
+
+  /**
+   * TTS Voice to use
+   */
+  sayVoice: string;
+
+  /**
+   * Path to Soundboard files
+   */
+  soundBoardPath: string;
+
+  /**
+   * Output path for combined Commands.txt
+   */
+  commandsPath: string;
+
+  /**
+   * Login token for twitch IRC client
+   */
+  twitchToken: string;
+
+  /**
+   * Enables debugging logging for twitch client
+   */
+  debug: boolean;
+
+  /**
+   * The maximum number of !say commands that can be queued at once
+   *
+   * -1 mean unlimited
+   */
+  maxSayQueue: number;
+}
+
+type ConfigFile = Partial<Config>;
+
+const requiredKeys = [ 'channel', 'soundBoardPath', 'commandsPath', 'twitchToken' ]
+
+const defaultConfig: Partial<Config> = {
+  botName: 'decebot',
+  sayVoice: 'Microsoft Zira Desktop',
+  debug: false,
+  maxSayQueue: -1
+};
+
+let configFile: ConfigFile;
+
+try {
+  configFile = require('../config.json');
+} catch {
+  try {
+    configFile = safeLoad(readFileSync('./config.yaml', 'utf8'));
+  } catch(e) {
+    console.error('No config file found. Please create config.json or config.yaml')
+    console.error(e)
+    process.exit(1)
+  }
+}
+
+const config = { ...defaultConfig, ...configFile } as Config;
+
+if (!Array.isArray(config.channels)) {
+  config.channels = [ config.channel ]
+}
+
+const providedKeys = new Set(Object.keys(config));
+
+const missingKeys = requiredKeys.filter(k => !providedKeys.has(k))
+
+if (missingKeys.length > 0) {
+  console.error(`Missing the following keys from your config file: [${missingKeys.join(', ')}]`);
+  process.exit(1)
+}
+
+export default config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,21 @@ export interface Config {
    * -1 mean unlimited
    */
   maxSayQueue: number;
+
+  /**
+   *  Max amount of time to allow a !say command to go on for
+   */
+  sayTimeout: number;
+
+  /**
+   * Time between queued !say commands
+   */
+  saySpacing: number
+
+  /**
+   * The amount of time a user must wait between !say commands
+   */
+  sayThrottleTime: number;
 }
 
 type ConfigFile = Partial<Config>;
@@ -58,7 +73,10 @@ const defaultConfig: Partial<Config> = {
   botName: 'decebot',
   sayVoice: 'Microsoft Zira Desktop',
   debug: false,
-  maxSayQueue: -1
+  maxSayQueue: -1,
+  sayThrottleTime: 60000,
+  sayTimeout: 10000,
+  saySpacing: 1000
 };
 
 let configFile: ConfigFile;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import Slippi from './Slippi';
 import { client } from './tmiClient';
 import { sayInChat, findCommandInMessage } from './utils';
 import { argv } from './commandLine';
+import config from './config';
 
 // Handle unhandled promise rejections
 process.on('unhandledRejection', (reason, p) => {
@@ -24,6 +25,10 @@ client.on('connected', function (a, p) {
 
 
 client.on('chat', function (channel, userstate, message, self) {
+  if (userstate.username === config.botName) {
+    return;
+  }
+
   const command = findCommandInMessage(message);
   if (command) {
     command.execute(userstate, message);

--- a/src/tmiClient.ts
+++ b/src/tmiClient.ts
@@ -1,12 +1,12 @@
 import { Client, Options } from "tmi.js";
 
-import * as config from '../config.json';
+import config from './config';
 
 export const botName = config.botName;
 
 const tmiOptions: Options = {
   options: {
-    debug: true,
+    debug: config.debug,
   },
   connection: {
     reconnect: true,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { client } from "./tmiClient";
 import { commands } from "./commands";
 
-import * as config from '../config.json';
+import config from './config';
 
 export type SayInChatFunc = (message: string) => void;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,3 +18,5 @@ export const findCommandInMessage = (message: string) => {
   }
   return null;
 }
+
+export const sleep = (duration:number) => new Promise(resolve => setTimeout(resolve, duration));


### PR DESCRIPTION
- Refactored config parsing to allow for default values and optional yaml config
- `Command` class is now an abstract class with essentially just the `execute()` method
- Moved auth, command throttle, and new queuing to decorator methods
- Bot will no longer process any messages it sent in chat